### PR TITLE
Define Config class inside SidekiqUniqueJobs module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,10 @@ dist: trusty
 sudo: required
 language: ruby
 cache: bundler
+services:
+  - redis-server
 
 before_install:
-  - sudo rm -rf /etc/apt/sources.list.d/rwky-redis.list
-  - sudo add-apt-repository ppa:chris-lea/redis-server -y
-  - sudo apt-get update -qy
-  - sudo apt-get install redis-server
-  - sudo service redis-server start
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
 before_script:

--- a/lib/sidekiq_unique_jobs.rb
+++ b/lib/sidekiq_unique_jobs.rb
@@ -43,8 +43,7 @@ module SidekiqUniqueJobs
 
   module_function
 
-  Concurrent::MutableStruct.new(
-    'Config',
+  Config = Concurrent::MutableStruct.new(
     :default_lock_timeout,
     :enabled,
     :unique_prefix,
@@ -54,7 +53,7 @@ module SidekiqUniqueJobs
   # The current configuration (See: {.configure} on how to configure)
   def config
     # Arguments here need to match the definition of the new class (see above)
-    @config ||= Concurrent::MutableStruct::Config.new(
+    @config ||= Config.new(
       0,
       true,
       'uniquejobs',

--- a/spec/unit/sidekiq_unique_jobs_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SidekiqUniqueJobs do
   describe '.config' do
     subject(:config) { described_class.config }
 
-    it { is_expected.to be_a(Concurrent::MutableStruct::Config) }
+    it { is_expected.to be_a(SidekiqUniqueJobs::Config) }
     its(:default_lock_timeout)     { is_expected.to eq(0) }
     its(:enabled)                  { is_expected.to eq(true) }
     its(:unique_prefix)            { is_expected.to eq('uniquejobs') }


### PR DESCRIPTION
`Config` class used to be defined in `Concurrent::MutableStruct` which
is external, i.e. defined in other library.